### PR TITLE
fixes typo

### DIFF
--- a/plotly-cookbook.Rmd
+++ b/plotly-cookbook.Rmd
@@ -161,7 +161,7 @@ subplot(
 
 #### Density plots
 
-In [Bars & histograms](#bars-histograms), we leveraged a number of algorithms in R for computing the "optimal" number of bins for a histogram, via `hist()`, and routing those results to `add_bars()`. We can leverage the `density()` function for computing kernel density estimates in a similar way, and routing the results to `add_lines()`, as is done in \@ref(fig:densities).
+In [Bars & histograms](#bars-histograms), we leverage a number of algorithms in R for computing the "optimal" number of bins for a histogram, via `hist()`, and routing those results to `add_bars()`. We can leverage the `density()` function for computing kernel density estimates in a similar way, and routing the results to `add_lines()`, as is done in \@ref(fig:densities).
 
 ```{r densities, fig.cap = "Various kernel density estimates.", screenshot.alt = "screenshots/densities"}
 kerns <- c("gaussian", "epanechnikov", "rectangular", 


### PR DESCRIPTION
we haven't gotten to that section yet, so shouldn't refer to it in the past tense